### PR TITLE
Always return tooltip text, then users could use their own code to fine tune tooltips

### DIFF
--- a/src/components/CalendarHeatmap.vue
+++ b/src/components/CalendarHeatmap.vue
@@ -204,6 +204,7 @@
 			}
 
 			function tooltipOptions(day: CalendarItem) {
+				// Always return tooltip text, then users could use their own code to fine tune tooltips
 				if (day.count !== undefined) {
 					if (props.tooltipFormatter) {
 						return props.tooltipFormatter(day, props.tooltipUnit!);

--- a/src/components/CalendarHeatmap.vue
+++ b/src/components/CalendarHeatmap.vue
@@ -204,19 +204,16 @@
 			}
 
 			function tooltipOptions(day: CalendarItem) {
-				if (props.tooltip) {
-					if (day.count !== undefined) {
-						if (props.tooltipFormatter) {
-							return props.tooltipFormatter(day, props.tooltipUnit!);
-						}
-						return `<b>${day.count} ${props.tooltipUnit}</b> ${lo.value.on} ${lo.value.months[ day.date.getMonth() ]} ${day.date.getDate()}, ${day.date.getFullYear()}`;
-					} else if (props.noDataText) {
-						return `${props.noDataText}`;
-					} else if (props.noDataText !== false) {
-						return `<b>No ${props.tooltipUnit}</b> ${lo.value.on} ${lo.value.months[ day.date.getMonth() ]} ${day.date.getDate()}, ${day.date.getFullYear()}`;
+				if (day.count !== undefined) {
+					if (props.tooltipFormatter) {
+						return props.tooltipFormatter(day, props.tooltipUnit!);
 					}
+					return `<b>${day.count} ${props.tooltipUnit}</b> ${lo.value.on} ${lo.value.months[ day.date.getMonth() ]} ${day.date.getDate()}, ${day.date.getFullYear()}`;
+				} else if (props.noDataText) {
+					return `${props.noDataText}`;
+				} else if (props.noDataText !== false) {
+					return `<b>No ${props.tooltipUnit}</b> ${lo.value.on} ${lo.value.months[ day.date.getMonth() ]} ${day.date.getDate()}, ${day.date.getFullYear()}`;
 				}
-				return undefined;
 			}
 
 			function getWeekPosition(index: number) {


### PR DESCRIPTION
Creating a lot of tippy instances is expensive.

I think CalendarHeatmap could always provide the tooltip content by `data-tippy-content` (even if `tooltip=false`), then users could use their own code to fine tune tooltips.


Thank you very much!

ps: [diff with ignoring space looks clearer](https://github.com/razorness/vue3-calendar-heatmap/pull/20/files?diff=unified&w=1) 😁 

![image](https://user-images.githubusercontent.com/2114189/226180793-7ec37fdc-4858-4aa4-af64-fb187ebb092d.png)

