### PR TITLE
import css file in the example of usage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ npm install -D vue3-calendar-heatmap tippy.js
 
 ```typescript:no-line-numbers
 import VueCalendarHeatmap from 'vue3-calendar-heatmap'
+import 'vue3-calendar-heatmap/dist/style.css';
 
 app.use(VueCalendarHeatmap)
 ```
@@ -44,6 +45,7 @@ app.use(VueCalendarHeatmap)
 
 ```typescript:no-line-numbers
 import { CalendarHeatmap } from 'vue3-calendar-heatmap'
+import 'vue3-calendar-heatmap/dist/style.css';
 
 app.component('CalendarHeatmap', CalendarHeatmap)
 ```
@@ -52,6 +54,7 @@ app.component('CalendarHeatmap', CalendarHeatmap)
 
 ```typescript:no-line-numbers
 import { CalendarHeatmap } from 'vue3-calendar-heatmap'
+import 'vue3-calendar-heatmap/dist/style.css';
 
 export default {
     components: {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ A lightweight calendar heatmap Vuejs component built on SVG, inspired by github'
 
 ```bash:no-line-numbers
 # install in your project
-yarn add vue3-calendar-heatmap tippy.js
+yarn add vue3-calendar-heatmap
 ```
 
   </CodeGroupItem>
@@ -24,7 +24,7 @@ yarn add vue3-calendar-heatmap tippy.js
 
 ```bash:no-line-numbers
 # install in your project
-npm install -D vue3-calendar-heatmap tippy.js
+npm install -D vue3-calendar-heatmap
 ```
 
   </CodeGroupItem>


### PR DESCRIPTION
> A css file is included when importing the package. You may have to setup your bundler to embed the css in your page.

Warning is not enough, the statement of importing css file should clearly show in the example of usage.

At the same time, `tippy.js` is include by your source code, so it is not necessary included in the installation guide.