### PR TITLE
Add `tippyProps` option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,16 @@ export default {
 <calendar-heatmap dark-mode .../>
 ```
 
+### tippyProps
+- Type: `Object`
+- Details:
+
+  Props object passed to [tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/).
+
+```html:no-line-numbers
+<calendar-heatmap :tippy-props="{ theme: 'tomato' }"/>
+```
+
 #### Example
 <Demo dark-mode/>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,7 +129,7 @@ export default {
   Props object passed to [tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/).
 
 ```html:no-line-numbers
-<calendar-heatmap :tippy-props="{ theme: 'tomato' }"/>
+<calendar-heatmap :tippy-props="{ placement: 'bottom' }"/>
 ```
 
 #### Example

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,6 +63,14 @@
 			:tooltip-unit="picked"
 			:vertical="orientation === 'vertical'"
 		/>
+    <h4>TippyProps</h4>
+    <calendar-heatmap
+      :values="values"
+      :end-date="endDate"
+      :style="{'max-width': orientation === 'vertical' ? '145px' :  '675px'}"
+      :tippy-props="{placement: 'bottom'}"
+      :vertical="orientation === 'vertical'"
+    />
 	</div>
 </template>
 

--- a/src/components/CalendarHeatmap.vue
+++ b/src/components/CalendarHeatmap.vue
@@ -147,6 +147,10 @@
 			tooltipFormatter: {
 				type: Function as PropType<TooltipFormatter>
 			},
+			tippyProps: {
+				type   : Object,
+				default: null,
+			},
 			vertical        : {
 				type   : Boolean,
 				default: false
@@ -200,7 +204,8 @@
 					tippySingleton = createSingleton(Array.from(tippyInstances.values()), {
 						overrides     : [],
 						moveTransition: 'transform 0.1s ease-out',
-						allowHTML     : true
+						allowHTML     : true,
+						...props.tippyProps,
 					});
 				}
 			}


### PR DESCRIPTION
Allow users to pass custom props to tippy.js, for example to render the tooltip on bottom:

<img width="383" alt="Screenshot 2024-05-02 at 14 55 21" src="https://github.com/razorness/vue3-calendar-heatmap/assets/115237/2fd38f38-19b0-41ba-9b5a-64dec6ff6b02">

This PR is also available on npm as `@silverwind/vue3-calendar-heatmap@2.0.6`.