### PR TITLE
Add support for weeks starting on monday, but only as an explicit parameter

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,6 +38,16 @@
 		<h4>Some (circles)</h4>
 		<calendar-heatmap :values="values" :end-date="endDate" :style="{'max-width': orientation === 'vertical' ? '145px' :  '675px'}" :round="5"
 						  :vertical="orientation === 'vertical'"/>
+						  <br>
+		<h4>Some (monday)</h4>
+		<calendar-heatmap
+			:values="values"
+			:end-date="endDate"
+			:style="{'max-width': orientation === 'vertical' ? '145px' :  '675px'}"
+			:vertical="orientation === 'vertical'"
+			:week-start="1"
+			no-data-text="NOTHING"
+		/>
 		<br>
 		<h4>Locale</h4>
 		<calendar-heatmap :values="values" :end-date="endDate" :style="{'max-width': orientation === 'vertical' ? '145px' :  '675px'}" :locale="{

--- a/src/components/CalendarHeatmap.vue
+++ b/src/components/CalendarHeatmap.vue
@@ -18,19 +18,19 @@
 					  :x="vertical ? SQUARE_SIZE : 0"
 					  :y="vertical ? SQUARE_SIZE - SQUARE_BORDER_SIZE : 20"
 				>
-					{{ lo.days[ 1 ] }}
+					{{ lo.days[ 1 + weekStart ] }}
 				</text>
 				<text class="vch__day__label"
 					  :x="vertical ? SQUARE_SIZE * 3 : 0"
 					  :y="vertical ? SQUARE_SIZE - SQUARE_BORDER_SIZE : 44"
 				>
-					{{ lo.days[ 3 ] }}
+					{{ lo.days[ 3 + weekStart ] }}
 				</text>
 				<text class="vch__day__label"
 					  :x="vertical ? SQUARE_SIZE * 5 : 0"
 					  :y="vertical ? SQUARE_SIZE - SQUARE_BORDER_SIZE : 69"
 				>
-					{{ lo.days[ 5 ] }}
+					{{ lo.days[ 5 + weekStart ] }}
 				</text>
 			</g>
 
@@ -159,6 +159,10 @@
 				type   : Number,
 				default: 0
 			},
+			weekStart       : {
+				type   : Number,
+				default: 0
+			},
 			darkMode        : Boolean
 		},
 		emits: [ 'dayClick' ],
@@ -273,7 +277,7 @@
 			watch(
 				[ values, tooltipUnit, tooltipFormatter, noDataText, max, rangeColor ],
 				() => {
-					heatmap.value = new Heatmap(props.endDate as Date, props.values, props.max);
+					heatmap.value = new Heatmap(props.endDate as Date, props.values, props.max, props.weekStart);
 					tippyInstances.forEach((item) => item.destroy());
 					nextTick(initTippy);
 				}

--- a/src/components/Heatmap.ts
+++ b/src/components/Heatmap.ts
@@ -58,15 +58,17 @@ export class Heatmap {
 	startDate: Date;
 	endDate: Date;
 	max: number;
+	weekStart: number;
 
 	private _values: Value[];
 	private _firstFullWeekOfMonths?: Month[];
 	private _activities?: Activities;
 	private _calendar?: Calendar;
 
-	constructor(endDate: Date | string, values: Value[], max?: number) {
+	constructor(endDate: Date | string, values: Value[], max?: number, weekStart?: number) {
 		this.endDate   = this.parseDate(endDate);
 		this.max       = max || Math.ceil((Math.max(...values.map(day => day.count)) / 5) * 4);
+		this.weekStart = weekStart ?? 0;
 		this.startDate = this.shiftDate(endDate, -Heatmap.DAYS_IN_ONE_YEAR);
 		this._values   = values;
 	}
@@ -102,7 +104,7 @@ export class Heatmap {
 
 	get calendar() {
 		if (!this._calendar) {
-			let date       = this.shiftDate(this.startDate, -this.getCountEmptyDaysAtStart());
+			let date       = this.shiftDate(this.startDate, -this.getCountEmptyDaysAtStart() + this.weekStart);
 			date           = new Date(date.getFullYear(), date.getMonth(), date.getDate());
 			this._calendar = new Array(this.weekCount);
 			for (let i = 0, len = this._calendar.length; i < len; i++) {


### PR DESCRIPTION
Most of the code is taken from Vue2 PR [julienr114/vue-calendar-heatmap#14](https://github.com/julienr114/vue-calendar-heatmap/pull/14), minus the problematic 4 MiB dependency used for auto-detection of locale.

This [would be useful e.g. for Forgejo](https://codeberg.org/forgejo/forgejo/issues/1791), as it could delegate that to a user option.